### PR TITLE
fix for beanstalk in 1.9.2

### DIFF
--- a/lib/activemessaging/adapters/beanstalk.rb
+++ b/lib/activemessaging/adapters/beanstalk.rb
@@ -22,7 +22,7 @@ module ActiveMessaging
           @host = cfg[:host] || 'localhost'
           @port = cfg[:port] || 11300
           
-          @connection = ::Beanstalk::Pool.new("#{@host}:#{@port}")
+          @connection = ::Beanstalk::Pool.new(["#{@host}:#{@port}"])
         end
         
         def disconnect


### PR DESCRIPTION
The beanstalk driver expects an array of hosts, not a single string. This works in 1.8.7 only because ruby strings used to have an each method that just returned the string itself. This was removed in 1.9.2. 

Nathan 
