### PR TITLE
Rails 3.1.0.rc4 - `_run_prepare_callbacks': undefined local variable or method `activemessaging'

### DIFF
--- a/lib/activemessaging/railtie.rb
+++ b/lib/activemessaging/railtie.rb
@@ -11,7 +11,7 @@ module ActiveMessaging
       
       if defined? Rails
         ActiveMessaging.logger.info "ActiveMessaging: Rails available: Adding dispatcher prepare callback."
-        ActionDispatch::Callbacks.to_prepare :activemessaging do
+        ActionDispatch::Callbacks.to_prepare do
           ActiveMessaging.reload_activemessaging
         end
       end


### PR DESCRIPTION
Seems to be an issue with the `to_prepare` call in [railtie.rb](https://github.com/kookster/activemessaging/blob/master/lib/activemessaging/railtie.rb#L14). It doesn't like the symbol. If I remove the symbol, the generators don't show up when I run `rails g`.

```
bender:test-app swhitt$ rails g controller HelloWorld
/Users/swhitt/.rvm/gems/ruby-1.9.2-p180@rails31rc4/gems/activesupport-3.1.0.rc4/lib/active_support/callbacks.rb:413:in `_run_prepare_callbacks': undefined local variable or method `activemessaging' for #<ActionDispatch::Reloader:0x00000104ba6260 @app=nil> (NameError)
  from /Users/swhitt/.rvm/gems/ruby-1.9.2-p180@rails31rc4/gems/activesupport-3.1.0.rc4/lib/active_support/callbacks.rb:81:in `run_callbacks'
  from /Users/swhitt/.rvm/gems/ruby-1.9.2-p180@rails31rc4/gems/actionpack-3.1.0.rc4/lib/action_dispatch/middleware/reloader.rb:46:in `prepare!'
  from /Users/swhitt/.rvm/gems/ruby-1.9.2-p180@rails31rc4/gems/railties-3.1.0.rc4/lib/rails/application/finisher.rb:41:in `block in <module:Finisher>'
  from /Users/swhitt/.rvm/gems/ruby-1.9.2-p180@rails31rc4/gems/railties-3.1.0.rc4/lib/rails/initializable.rb:25:in `instance_exec'
  from /Users/swhitt/.rvm/gems/ruby-1.9.2-p180@rails31rc4/gems/railties-3.1.0.rc4/lib/rails/initializable.rb:25:in `run'
  from /Users/swhitt/.rvm/gems/ruby-1.9.2-p180@rails31rc4/gems/railties-3.1.0.rc4/lib/rails/initializable.rb:50:in `block in run_initializers'
  from /Users/swhitt/.rvm/gems/ruby-1.9.2-p180@rails31rc4/gems/railties-3.1.0.rc4/lib/rails/initializable.rb:49:in `each'
  from /Users/swhitt/.rvm/gems/ruby-1.9.2-p180@rails31rc4/gems/railties-3.1.0.rc4/lib/rails/initializable.rb:49:in `run_initializers'
  from /Users/swhitt/.rvm/gems/ruby-1.9.2-p180@rails31rc4/gems/railties-3.1.0.rc4/lib/rails/application.rb:96:in `initialize!'
  from /Users/swhitt/.rvm/gems/ruby-1.9.2-p180@rails31rc4/gems/railties-3.1.0.rc4/lib/rails/railtie/configurable.rb:30:in `method_missing'
  from /Users/swhitt/projects/idt/test-app/config/environment.rb:5:in `<top (required)>'
  from /Users/swhitt/.rvm/gems/ruby-1.9.2-p180@rails31rc4/gems/activesupport-3.1.0.rc4/lib/active_support/dependencies.rb:237:in `require'
  from /Users/swhitt/.rvm/gems/ruby-1.9.2-p180@rails31rc4/gems/activesupport-3.1.0.rc4/lib/active_support/dependencies.rb:237:in `block in require'
  from /Users/swhitt/.rvm/gems/ruby-1.9.2-p180@rails31rc4/gems/activesupport-3.1.0.rc4/lib/active_support/dependencies.rb:223:in `block in load_dependency'
  from /Users/swhitt/.rvm/gems/ruby-1.9.2-p180@rails31rc4/gems/activesupport-3.1.0.rc4/lib/active_support/dependencies.rb:639:in `new_constants_in'
  from /Users/swhitt/.rvm/gems/ruby-1.9.2-p180@rails31rc4/gems/activesupport-3.1.0.rc4/lib/active_support/dependencies.rb:223:in `load_dependency'
  from /Users/swhitt/.rvm/gems/ruby-1.9.2-p180@rails31rc4/gems/activesupport-3.1.0.rc4/lib/active_support/dependencies.rb:237:in `require'
  from /Users/swhitt/.rvm/gems/ruby-1.9.2-p180@rails31rc4/gems/railties-3.1.0.rc4/lib/rails/application.rb:78:in `require_environment!'
  from /Users/swhitt/.rvm/gems/ruby-1.9.2-p180@rails31rc4/gems/railties-3.1.0.rc4/lib/rails/commands.rb:22:in `<top (required)>'
  from script/rails:6:in `require'
  from script/rails:6:in `<main>'
```
