### PR TITLE
Fix two separate problems with the JMS adapter

### DIFF
--- a/lib/activemessaging/adapters/jms.rb
+++ b/lib/activemessaging/adapters/jms.rb
@@ -1,10 +1,13 @@
-
 if defined?(JRUBY_VERSION)
 #require 'java'
 include Java
 
-import javax.naming.InitialContext
-import javax.jms.MessageListener
+begin
+  java_import javax.naming.InitialContext
+  java_import javax.jms.MessageListener
+rescue NameError
+  raise LoadError, "ActiveMessaging::Adapter::Jms needs Jave EE classes on the CLASSPATH"
+end
 
 module ActiveMessaging
   module Adapters


### PR DESCRIPTION
- If JMS classes are not available on the CLASSPATH,
  ActiveMessaging should skip the JMS adapter
  instead of aborting startup.
- java_import is necessary when running under Rake
  (since Rake defines Object#import)
