### PR TITLE
Bug in setting reliable in stomp adapter

### DIFF
--- a/lib/activemessaging/adapters/stomp.rb
+++ b/lib/activemessaging/adapters/stomp.rb
@@ -20,7 +20,7 @@ module ActiveMessaging
           cfg[:passcode] ||= ""
           cfg[:host] ||= "localhost"
           cfg[:port] ||= "61613"
-          cfg[:reliable]  = cfg[:reliable].nil? ? TRUE : cfg[:reliable].nil?
+          cfg[:reliable]  = cfg[:reliable].nil? ? TRUE : cfg[:reliable]
           cfg[:reconnectDelay] ||= 5
           cfg[:clientId] ||= nil
 


### PR DESCRIPTION
Fixed bug in the setting of the reliable configuration setting in the stomp adapter.  With the bug, setting 'reliable: true' in the broker.yml results in reliable being set to false in the stomp client.  This fix will allow any setting of reliable in broker.yml to be passed to the stomp client and defaults to reliable being true if no setting is specified in broker.yml (which is how it should work).
