### PR TITLE
Pass full connect_headers hash through to stomp gem

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    activemessaging (0.11.0)
+    activemessaging (0.12.0)
       activemessaging
       activesupport (>= 2.3.11)
       celluloid
@@ -9,7 +9,7 @@ PATH
 GEM
   remote: http://rubygems.org/
   specs:
-    activesupport (3.2.7)
+    activesupport (3.2.8)
       i18n (~> 0.6)
       multi_json (~> 1.0)
     appraisal (0.4.1)

--- a/lib/activemessaging/adapters/stomp.rb
+++ b/lib/activemessaging/adapters/stomp.rb
@@ -28,7 +28,7 @@ module ActiveMessaging
           @configuration = cfg
 
           # create a new stomp connection
-          connect_headers = {}
+          connect_headers = cfg[:connect_headers] || {}
           connect_headers['client-id'] = cfg[:clientId] if cfg[:clientId]
           @stomp_connection = ::Stomp::Connection.new(cfg[:login],cfg[:passcode],cfg[:host],cfg[:port].to_i,cfg[:reliable],cfg[:reconnectDelay], connect_headers)
         end


### PR DESCRIPTION
This allows you to do things like specify the vhost if you are connecting to rabbitmq's stomp connector
