### PR TITLE
Updates to allow installation of activemessaging and running of Rails 3 generators.

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,12 @@ Here's a sample of a processor class that handles incoming messages:
     	end
     end
 
+# Generating with Rails 3
+
+After adding ActiveMessaging to your Gemfile and executing bundle install, run the following commands:
+
+rails g active_messaging:install  
+rails g active_messaging:processor <NameOfYourProcessor>
 
 # Support
 

--- a/activemessaging.gemspec
+++ b/activemessaging.gemspec
@@ -111,19 +111,20 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
   s.rubygems_version = "1.8.22"
   s.summary = "Official activemessaging gem, now hosted on github.com/kookster. (kookster prefix temporary)"
-
+  
+  # Having activemessaging > 0 is blocking gem from installing it.
   if s.respond_to? :specification_version then
     s.specification_version = 3
 
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
-      s.add_runtime_dependency(%q<activemessaging>, [">= 0"])
+      #s.add_runtime_dependency(%q<activemessaging>, [">= 0"])
       s.add_runtime_dependency(%q<activesupport>, [">= 2.3.11"])
       s.add_runtime_dependency(%q<celluloid>, [">= 0"])
       s.add_development_dependency(%q<jeweler>, [">= 0"])
       s.add_development_dependency(%q<stomp>, [">= 0"])
       s.add_development_dependency(%q<appraisal>, [">= 0"])
     else
-      s.add_dependency(%q<activemessaging>, [">= 0"])
+      #s.add_dependency(%q<activemessaging>, [">= 0"])
       s.add_dependency(%q<activesupport>, [">= 2.3.11"])
       s.add_dependency(%q<celluloid>, [">= 0"])
       s.add_dependency(%q<jeweler>, [">= 0"])
@@ -131,7 +132,7 @@ Gem::Specification.new do |s|
       s.add_dependency(%q<appraisal>, [">= 0"])
     end
   else
-    s.add_dependency(%q<activemessaging>, [">= 0"])
+    #s.add_dependency(%q<activemessaging>, [">= 0"])
     s.add_dependency(%q<activesupport>, [">= 2.3.11"])
     s.add_dependency(%q<celluloid>, [">= 0"])
     s.add_dependency(%q<jeweler>, [">= 0"])

--- a/lib/activemessaging.rb
+++ b/lib/activemessaging.rb
@@ -65,9 +65,15 @@ module ActiveMessaging
   end
 
   def self.load_config
+    # Skip loading config if there are no custom processors as the generator 
+    # is likely running since application_processor.rb and another processor
+    # should exist when running rails. 
+    if Dir["#{app_root}/app/processors/*.rb"].size() <= 1
+	return
+    end
     path = File.expand_path("#{app_root}/config/messaging.rb")
     begin
-      load path
+      load path 
     rescue
       raise $!, " ActiveMessaging: problems trying to load '#{path}': \n\t#{$!.message}"
     end

--- a/lib/generators/active_messaging/install/install_generator.rb
+++ b/lib/generators/active_messaging/install/install_generator.rb
@@ -3,11 +3,11 @@ module ActiveMessaging
     source_root File.expand_path("../templates", __FILE__)
     
     argument :poller_name, :type => :string, :default => 'poller', :banner => 'poller_name'
-
+     
     def copy_application
       copy_file "application_processor.rb", "app/processors/application_processor.rb"
     end
-    
+
     def copy_poller
       template "poller", "script/#{poller_name}"
       chmod("script/#{poller_name}", 0755)
@@ -25,12 +25,12 @@ module ActiveMessaging
     def copy_broker_rb
       copy_file "broker.yml", "config/broker.yml"
     end
-    
+
     def add_gems
       gem("daemons")
     end
-    
-   
+  
+ 
     def change_application
       application '  config.autoload_paths += %W(#{config.root}/app/processors)'
     end

--- a/lib/generators/active_messaging/processor/processor_generator.rb
+++ b/lib/generators/active_messaging/processor/processor_generator.rb
@@ -4,7 +4,7 @@ module ActiveMessaging
     source_root File.expand_path("../templates", __FILE__)
 
     # check_class_collision :suffix=>"Processor"
-    
+ 
     def copy_processor
       template "processor.rb", "app/processors/#{file_name}_processor.rb"
     end


### PR DESCRIPTION
With Rails 3.2.8 and Gem version 1.8.24, I could not get the activemessaging 0.12.0 gem to install.  The dependency on activemessaging >= 0 in the gemspec was blocking gem from install activemessaging.  Once the dependency was commented out, the generators would fail.  The generators fails, since load_config in lib/activemessaging.rb couldn't find messaging.rb as it hadn't been placed in config by the generators.  I couldn't find an easy way to see if the generator was running, so load_config skips loading messaging.rb if there isn't at least two *.rb files in app/processors, since that indicates that application_processor.rb and a user processor aren't available yet.  I als added a section in README.md on how to run the generators in Rails 3 as the old wiki doesn't appear to document updated method.  Feel free to use these changes if you desire.
