### PR TITLE
Fix AMQP adapter configuration

### DIFF
--- a/lib/activemessaging/adapters/amqp.rb
+++ b/lib/activemessaging/adapters/amqp.rb
@@ -61,7 +61,7 @@ module ActiveMessaging
 
           @queue_config = DEFAULT_QUEUE_CONFIG
           unless @auto_generated_queue
-            @queue_config.merge({
+            @queue_config.merge!({
               :durable     => !!config[:queue_durable],
               :auto_delete => !!config[:queue_auto_delete],
               :exclusive   => !!config[:queue_exclusive]


### PR DESCRIPTION
The AMQP adapter was unable to use overridden defaults in the configuration file (queue_durable, queue_exclusive, queue_auto_delete).  Fixed here.
