### PR TITLE
[#25] Only require threaded_poller where necessary

### DIFF
--- a/lib/activemessaging.rb
+++ b/lib/activemessaging.rb
@@ -14,12 +14,12 @@ module ActiveMessaging
   class StopProcessingException < Interrupt #:nodoc:
   end
 
-  # Used to indicate that the processing on a message should cease, 
+  # Used to indicate that the processing on a message should cease,
   # and the message should be returned back to the broker as best it can be
   class AbortMessageException < Exception #:nodoc:
   end
 
-  # Used to indicate that the processing on a message should cease, 
+  # Used to indicate that the processing on a message should cease,
   # but no further action is required
   class StopFilterException < Exception #:nodoc:
   end
@@ -46,15 +46,14 @@ module ActiveMessaging
   def self.load_extensions
     require 'logger'
     require 'activemessaging/gateway'
-    require 'activemessaging/threaded_poller'
     require 'activemessaging/adapter'
     require 'activemessaging/message_sender'
     require 'activemessaging/processor'
     require 'activemessaging/filter'
     require 'activemessaging/trace_filter'
 
-    # load all under the adapters dir 
-    Dir[File.join(ROOT, 'lib', 'activemessaging', 'adapters', '*.rb')].each do |a| 
+    # load all under the adapters dir
+    Dir[File.join(ROOT, 'lib', 'activemessaging', 'adapters', '*.rb')].each do |a|
       begin
         adapter_name = File.basename(a, ".rb")
         require 'activemessaging/adapters/' + adapter_name
@@ -106,7 +105,7 @@ module ActiveMessaging
       err_msg = <<-EOM
 
       ActiveMessaging Error: No subscriptions.
-      
+
       If you have no processor classes in app/processors, add them using the command:
         script/generate processor DoSomething"
 

--- a/lib/generators/active_messaging/install/templates/threaded_poller
+++ b/lib/generators/active_messaging/install/templates/threaded_poller
@@ -26,6 +26,7 @@ Dir["#{lib_path}/**/*.rb"].each {|file| require file unless file.match(/poller\.
 # require and load activemessaging
 require 'activemessaging'
 ActiveMessaging.load_activemessaging
+require 'activemessaging/threaded_poller'
 
 # configure the connection (there can be multiple defined in broker.yml) and number of threads
 connection_name = 'default'


### PR DESCRIPTION
Removes the threaded_poller requirement from activemessaging.rb and moves it into script/threaded_poller
