### PR TITLE
Fix ACKs for Stomp protocol level 1.2 connection.

### DIFF
--- a/lib/activemessaging/adapters/stomp.rb
+++ b/lib/activemessaging/adapters/stomp.rb
@@ -83,10 +83,12 @@ module ActiveMessaging
           # if the ack mode is client or client-individual, send an ack
           if (headers[:ack] === 'client' || headers[:ack] === 'client-individual')
             ack_headers = message.headers.has_key?(:transaction) ? { :transaction=>message.headers[:transaction]} : {}
+            # All 3 protocol levels have unique ACK requirements.
             case @stomp_connection.protocol
               when ::Stomp::SPL_10
                 @stomp_connection.ack(message.headers['message-id'], ack_headers)
               when ::Stomp::SPL_11
+                ack_headers['subscription'] = message.headers['subscription']
                 @stomp_connection.ack(message.headers['message-id'], ack_headers)
               else # avoid ::Stomp::SPL_12 constant when using older Stomp gems
                 @stomp_connection.ack(message.headers['ack'], ack_headers)


### PR DESCRIPTION
Originally reported and details at:
https://github.com/stompgem/stomp/issues/59
