### PR TITLE
Removed dependency on itself

### DIFF
--- a/activemessaging.gemspec
+++ b/activemessaging.gemspec
@@ -117,14 +117,12 @@ Gem::Specification.new do |s|
     s.specification_version = 4
 
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
-      s.add_runtime_dependency(%q<activemessaging>, [">= 0"])
       s.add_development_dependency(%q<jeweler>, [">= 0"])
       s.add_runtime_dependency(%q<activesupport>, [">= 2.3.11"])
       s.add_development_dependency(%q<jeweler>, [">= 0"])
       s.add_development_dependency(%q<stomp>, [">= 0"])
       s.add_development_dependency(%q<appraisal>, [">= 0"])
     else
-      s.add_dependency(%q<activemessaging>, [">= 0"])
       s.add_dependency(%q<jeweler>, [">= 0"])
       s.add_dependency(%q<activesupport>, [">= 2.3.11"])
       s.add_dependency(%q<jeweler>, [">= 0"])
@@ -132,7 +130,6 @@ Gem::Specification.new do |s|
       s.add_dependency(%q<appraisal>, [">= 0"])
     end
   else
-    s.add_dependency(%q<activemessaging>, [">= 0"])
     s.add_dependency(%q<jeweler>, [">= 0"])
     s.add_dependency(%q<activesupport>, [">= 2.3.11"])
     s.add_dependency(%q<jeweler>, [">= 0"])


### PR DESCRIPTION
Our Jenkins build for our application has just started failing for some reason with this error:

```
+ RAILS_ENV=test bundle install -j4 --path vendor/gems
Fetching gem metadata from https://rubygems.org/........
Fetching version metadata from https://rubygems.org/...
Fetching dependency metadata from https://rubygems.org/..
Resolving dependencies....
Your Gemfile requires gems that depend on each other, creating an infinite loop.
Please remove gem 'activemessaging' and try again.
Build step 'Execute shell' marked build as failure
Build failed, skipping rcov coverage report
Build step 'Publish Rcov report' marked build as failure
Finished: FAILURE
```

The reason seems to be that activemessaging depends on itself.  I've tested this with a local clone, remove this cyclic dependency and all is well again.  I don't know why it's suddenly reared its head, maybe a new version of Bundler...