### PR TITLE
Removed duplicated jeweler dependencies from gemspec

### DIFF
--- a/activemessaging.gemspec
+++ b/activemessaging.gemspec
@@ -119,20 +119,17 @@ Gem::Specification.new do |s|
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
       s.add_development_dependency(%q<jeweler>, [">= 0"])
       s.add_runtime_dependency(%q<activesupport>, [">= 2.3.11"])
-      s.add_development_dependency(%q<jeweler>, [">= 0"])
       s.add_development_dependency(%q<stomp>, [">= 0"])
       s.add_development_dependency(%q<appraisal>, [">= 0"])
     else
       s.add_dependency(%q<jeweler>, [">= 0"])
       s.add_dependency(%q<activesupport>, [">= 2.3.11"])
-      s.add_dependency(%q<jeweler>, [">= 0"])
       s.add_dependency(%q<stomp>, [">= 0"])
       s.add_dependency(%q<appraisal>, [">= 0"])
     end
   else
     s.add_dependency(%q<jeweler>, [">= 0"])
     s.add_dependency(%q<activesupport>, [">= 2.3.11"])
-    s.add_dependency(%q<jeweler>, [">= 0"])
     s.add_dependency(%q<stomp>, [">= 0"])
     s.add_dependency(%q<appraisal>, [">= 0"])
   end


### PR DESCRIPTION
Fixes #42

Now Bundler install it from git checkout or local path. But I don't know how to use it.

Thanks @alfredolopez-kantox for noticing error message here: https://github.com/kookster/activemessaging/issues/42#issuecomment-154498528.

Could you please publish new gem on rubygems after merging this in?