### PR TITLE
Rails 5.1 -- Call to_prepare from config object.

### DIFF
--- a/lib/activemessaging/railtie.rb
+++ b/lib/activemessaging/railtie.rb
@@ -4,23 +4,22 @@ require 'activemessaging'
 
 module ActiveMessaging
   class Railtie < Rails::Railtie
-    
     initializer 'activemessaging.initialize' do
       
       ActiveMessaging.load_activemessaging
-      
+
+      # Add a to_prepare block which is executed once in production
+      # and before each request in development
       if defined? Rails
         ActiveMessaging.logger.info "ActiveMessaging: Rails available: Adding dispatcher prepare callback."
-        ActionDispatch::Callbacks.to_prepare do
+        config.to_prepare do
           ActiveMessaging.reload_activemessaging
         end
       end
-
     end
 
     rake_tasks do
       load "tasks/start_consumers.rake"
     end
-    
   end
 end

--- a/lib/activemessaging/railtie.rb
+++ b/lib/activemessaging/railtie.rb
@@ -12,8 +12,15 @@ module ActiveMessaging
       # and before each request in development
       if defined? Rails
         ActiveMessaging.logger.info "ActiveMessaging: Rails available: Adding dispatcher prepare callback."
-        config.to_prepare do
-          ActiveMessaging.reload_activemessaging
+        case
+          when Gem::Version.new(Rails.version) < Gem::Version.new('3.0.0')
+            ActionDispatch::Callbacks.to_prepare do
+              ActiveMessaging.reload_activemessaging
+            end
+          else
+            config.to_prepare do
+              ActiveMessaging.reload_activemessaging
+            end
         end
       end
     end


### PR DESCRIPTION
Change call to `to_prepare` to call from config object.

This is necessary for Rails 5.1, or the gem will not run, and the Rails server will not start.

We are now using the gem from this code change, and have done initial testing.  This queues a message and gets a result.