### PR TITLE
Use OpenSSL::Digest instead of deprecated class

### DIFF
--- a/lib/activemessaging/adapters/asqs.rb
+++ b/lib/activemessaging/adapters/asqs.rb
@@ -266,7 +266,7 @@ module ActiveMessaging
       		# Sign the string
       		sorted_params = params.sort_by { |key,value| key.downcase }
       		string_to_sign = sorted_params.collect { |key, value| key.to_s + value.to_s }.join()
-      		digest = OpenSSL::Digest::Digest.new('sha1')
+      		digest = OpenSSL::Digest.new('sha1')
           hmac = OpenSSL::HMAC.digest(digest, @secret_access_key, string_to_sign)
           params['Signature'] = Base64.encode64(hmac).chomp
 


### PR DESCRIPTION
`OpenSSL::Digest` is [available](https://github.com/ruby/ruby/blob/ruby_1_8/ext/openssl/lib/openssl/digest.rb) since ruby 1.8
